### PR TITLE
Rename GoSSHRun New method to Init

### DIFF
--- a/cmd/frpc/gssh_runner.go
+++ b/cmd/frpc/gssh_runner.go
@@ -37,7 +37,7 @@ type GoSSHRun struct {
 	tcs map[int]*gssh.TunnelClient
 }
 
-func (gr *GoSSHRun) New(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error {
+func (gr *GoSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error {
 	log.Infof("init go ssh runner")
 
 	runner = &GoSSHRun{

--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	log.Infof("common cfg: %v, proxy cfg: %v, visitor cfg: %v", util.JSONEncode(cfg), util.JSONEncode(proxyCfgs), util.JSONEncode(visitorCfgs))
 
-	err = runner.New(cfg, proxyCfgs, visitorCfgs)
+	err = runner.Init(cfg, proxyCfgs, visitorCfgs)
 	if err != nil {
 		log.Errorf("new runner error: %v", err)
 		return


### PR DESCRIPTION
Renames the `New` method to `Init` in the `GoSSHRun` struct and updates all relevant calls to this method.

- **Method Renaming**: The `New` method in `GoSSHRun` struct within `cmd/frpc/gssh_runner.go` is renamed to `Init`. This change aligns with the task's requirement to replace the `New` method with `Init` for initialization purposes.
- **Codebase Update**: Adjusts the initialization call in `cmd/frpc/main.go` from `runner.New` to `runner.Init`, ensuring consistency with the method renaming in the `GoSSHRun` struct.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gofrp/tiny-frpc?shareId=855dfb10-72ce-4e31-b7a8-3cfb2e6612f7).