### PR TITLE
Refactor runner implementations to use New functions

### DIFF
--- a/cmd/frpc/default_runner.go
+++ b/cmd/frpc/default_runner.go
@@ -20,14 +20,12 @@ import (
 	"github.com/gofrp/tiny-frpc/pkg/util/log"
 )
 
-var runner model.Runner = defaultRunner{}
+func NewRunner(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (model.Runner, error) {
+	log.Infof("init default runner")
+	return defaultRunner{}, nil
+}
 
 type defaultRunner struct{}
-
-func (r defaultRunner) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (err error) {
-	log.Infof("init default runner")
-	return
-}
 
 func (r defaultRunner) Run() (err error) {
 	return

--- a/cmd/frpc/gssh_runner.go
+++ b/cmd/frpc/gssh_runner.go
@@ -37,10 +37,10 @@ type GoSSHRun struct {
 	tcs map[int]*gssh.TunnelClient
 }
 
-func (gr *GoSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error {
+func NewRunner(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (*GoSSHRun, error) {
 	log.Infof("init go ssh runner")
 
-	runner = &GoSSHRun{
+	return &GoSSHRun{
 		commonCfg: commonCfg,
 		pxyCfg:    pxyCfg,
 		vCfg:      vCfg,
@@ -49,8 +49,7 @@ func (gr *GoSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConf
 		mu: &sync.RWMutex{},
 
 		tcs: make(map[int]*gssh.TunnelClient, 0),
-	}
-	return nil
+	}, nil
 }
 
 func (gr *GoSSHRun) Run() error {
@@ -103,8 +102,4 @@ func (gr *GoSSHRun) Close() error {
 		tc.Close()
 	}
 	return nil
-}
-
-func init() {
-	runner = &GoSSHRun{}
 }

--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -44,13 +44,13 @@ func main() {
 		return
 	}
 
-	setupSignalHandler(runner)
-
-	err = runner.Init(cfg, proxyCfgs, visitorCfgs)
+	runner, err := NewRunner(cfg, proxyCfgs, visitorCfgs)
 	if err != nil {
 		log.Errorf("new runner error: %v", err)
 		return
 	}
+
+	setupSignalHandler(runner)
 
 	err = runner.Run()
 	if err != nil {

--- a/cmd/frpc/nssh_runner.go
+++ b/cmd/frpc/nssh_runner.go
@@ -40,12 +40,12 @@ type NativeSSHRun struct {
 	cancelFunc context.CancelFunc
 }
 
-func (nr *NativeSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error {
+func NewRunner(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (*NativeSSHRun, error) {
 	log.Infof("init native ssh runner")
 
-	nr.ctx, nr.cancelFunc = context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	runner = &NativeSSHRun{
+	return &NativeSSHRun{
 		commonCfg: commonCfg,
 		pxyCfg:    pxyCfg,
 		vCfg:      vCfg,
@@ -54,8 +54,9 @@ func (nr *NativeSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.Proxy
 		mu: &sync.RWMutex{},
 
 		cws: make(map[int]*nssh.CmdWrapper, 0),
-	}
-	return nil
+		ctx: ctx,
+		cancelFunc: cancelFunc,
+	}, nil
 }
 
 func (nr *NativeSSHRun) Run() error {
@@ -99,8 +100,4 @@ func (nr *NativeSSHRun) Close() error {
 	}
 
 	return nil
-}
-
-func init() {
-	runner = &NativeSSHRun{}
 }


### PR DESCRIPTION
This pull request introduces significant changes to the runner implementation across various files in the gofrp/tiny-frpc project, focusing on removing global variables and replacing `Init` methods with `New` functions for runner instances creation.

- **Removes global `runner` variable**: The global `runner` variable is removed from `cmd/frpc/main.go`, `cmd/frpc/gssh_runner.go`, and `cmd/frpc/nssh_runner.go`, aligning with the task's requirement to avoid using global state for runner instances.
- **Introduces `NewRunner` functions**: Replaces the `Init` method with a `NewRunner` function in `cmd/frpc/default_runner.go`, `cmd/frpc/gssh_runner.go`, and `cmd/frpc/nssh_runner.go`. Each `NewRunner` function is responsible for creating and returning a new instance of the respective runner, adhering to the `model.Runner` interface. This change ensures that runner instances are created through a consistent and controlled process.
- **Updates `main.go` to use `NewRunner`**: In `cmd/frpc/main.go`, the code is updated to use the `NewRunner` function for creating a runner instance instead of directly assigning a global variable. This modification supports the objective of eliminating global state in favor of instance-based runner management.

These changes collectively enhance the codebase's structure by promoting better practices for managing runner instances, thereby improving maintainability and scalability of the project.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gofrp/tiny-frpc?shareId=e15405eb-e2e8-45e3-bec5-f48242244a33).