### PR TITLE
Refactor runner interface to use New functions

### DIFF
--- a/cmd/frpc/default_runner.go
+++ b/cmd/frpc/default_runner.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !gssh && !nssh
+// +build !gssh,!nssh
+
 package main
 
 import (
@@ -20,14 +23,12 @@ import (
 	"github.com/gofrp/tiny-frpc/pkg/util/log"
 )
 
-var runner model.Runner = defaultRunner{}
+func NewRunner(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (model.Runner, error) {
+	log.Infof("init default runner")
+	return defaultRunner{}, nil
+}
 
 type defaultRunner struct{}
-
-func (r defaultRunner) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (err error) {
-	log.Infof("init default runner")
-	return
-}
 
 func (r defaultRunner) Run() (err error) {
 	return

--- a/cmd/frpc/gssh_runner.go
+++ b/cmd/frpc/gssh_runner.go
@@ -37,10 +37,10 @@ type GoSSHRun struct {
 	tcs map[int]*gssh.TunnelClient
 }
 
-func (gr *GoSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error {
+func NewRunner(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (*GoSSHRun, error) {
 	log.Infof("init go ssh runner")
 
-	runner = &GoSSHRun{
+	return &GoSSHRun{
 		commonCfg: commonCfg,
 		pxyCfg:    pxyCfg,
 		vCfg:      vCfg,
@@ -49,8 +49,7 @@ func (gr *GoSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConf
 		mu: &sync.RWMutex{},
 
 		tcs: make(map[int]*gssh.TunnelClient, 0),
-	}
-	return nil
+	}, nil
 }
 
 func (gr *GoSSHRun) Run() error {
@@ -103,8 +102,4 @@ func (gr *GoSSHRun) Close() error {
 		tc.Close()
 	}
 	return nil
-}
-
-func init() {
-	runner = &GoSSHRun{}
 }

--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -44,13 +44,13 @@ func main() {
 		return
 	}
 
-	setupSignalHandler(runner)
-
-	err = runner.Init(cfg, proxyCfgs, visitorCfgs)
+	runner, err := NewRunner(cfg, proxyCfgs, visitorCfgs)
 	if err != nil {
 		log.Errorf("new runner error: %v", err)
 		return
 	}
+
+	setupSignalHandler(runner)
 
 	err = runner.Run()
 	if err != nil {

--- a/cmd/frpc/nssh_runner.go
+++ b/cmd/frpc/nssh_runner.go
@@ -40,12 +40,12 @@ type NativeSSHRun struct {
 	cancelFunc context.CancelFunc
 }
 
-func (nr *NativeSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error {
+func NewRunner(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) (*NativeSSHRun, error) {
 	log.Infof("init native ssh runner")
 
-	nr.ctx, nr.cancelFunc = context.WithCancel(context.Background())
+	ctx, cancelFunc := context.WithCancel(context.Background())
 
-	runner = &NativeSSHRun{
+	return &NativeSSHRun{
 		commonCfg: commonCfg,
 		pxyCfg:    pxyCfg,
 		vCfg:      vCfg,
@@ -53,9 +53,10 @@ func (nr *NativeSSHRun) Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.Proxy
 		wg: new(sync.WaitGroup),
 		mu: &sync.RWMutex{},
 
-		cws: make(map[int]*nssh.CmdWrapper, 0),
-	}
-	return nil
+		cws:        make(map[int]*nssh.CmdWrapper, 0),
+		ctx:        ctx,
+		cancelFunc: cancelFunc,
+	}, nil
 }
 
 func (nr *NativeSSHRun) Run() error {
@@ -99,8 +100,4 @@ func (nr *NativeSSHRun) Close() error {
 	}
 
 	return nil
-}
-
-func init() {
-	runner = &NativeSSHRun{}
 }

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -14,12 +14,7 @@
 
 package model
 
-import (
-	v1 "github.com/gofrp/tiny-frpc/pkg/config/v1"
-)
-
 type Runner interface {
-	Init(commonCfg *v1.ClientCommonConfig, pxyCfg []v1.ProxyConfigurer, vCfg []v1.VisitorConfigurer) error
 	Run() error
 	Close() error
 }


### PR DESCRIPTION
Replaces the `Init` method with a `New` function across all runner implementations and removes the global `runner` variable in favor of local runner instances.

- **Removes** the `Init` method from the `Runner` interface in `pkg/model/interface.go`, aligning with the task's requirement to eliminate global state in favor of explicit initialization.
- **Introduces** `NewRunner` functions in `default_runner.go`, `gssh_runner.go`, and `nssh_runner.go` files, which return new instances of their respective runners. This change ensures that runners are created through these functions rather than relying on global variables or an `Init` method.
- **Updates** `main.go` to use the new `NewRunner` function for runner initialization, replacing the previous global `runner` variable with a locally scoped variable. This modification supports the goal of reducing global state within the application.
- **Adjusts** runner implementations (`defaultRunner`, `GoSSHRun`, `NativeSSHRun`) to remove the `Init` method and instead rely on the `NewRunner` function for initialization, reflecting a shift towards explicit dependency injection and improving the clarity of runner creation.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gofrp/tiny-frpc?shareId=bac10221-fbbe-4b93-9d15-f62d64b69323).