### PR TITLE
Remove gssh tags and add make test to CI

### DIFF
--- a/.github/workflows/go-code-check.yml
+++ b/.github/workflows/go-code-check.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+      - name: Test
+        run: make test

--- a/Makefile.cross-compiles
+++ b/Makefile.cross-compiles
@@ -14,7 +14,7 @@ app:
 		gomips=$(shell echo "$(n)" | cut -d : -f 3);\
 		target_suffix=$${os}_$${arch};\
 		echo "Build $${os}-$${arch}...";\
-		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -tags gssh -o ./release/tiny-frpc_$${target_suffix} ./cmd/frpc;\
+		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -o ./release/tiny-frpc_$${target_suffix} ./cmd/frpc;\
 		env CGO_ENABLED=0 GOOS=$${os} GOARCH=$${arch} GOMIPS=$${gomips} go build -trimpath -ldflags "$(LDFLAGS)" -tags nssh -o ./release/tiny-frpc-ssh_$${target_suffix} ./cmd/frpc;\
 		echo "Build $${os}-$${arch} done";\
 	)


### PR DESCRIPTION
Removes compilation tags for gssh in `Makefile.cross-compiles` and adds a test step in `.github/workflows/go-code-check.yml`.

- **Makefile.cross-compiles**: Removes `-tags gssh` from the `go build` command to eliminate the compilation tags for gssh. This change simplifies the build process for `./release/tiny-frpc_$${target_suffix}`.
- **.github/workflows/go-code-check.yml**: Adds a new step named `Test` after the `Vet` step to run `make test`, incorporating test execution into the CI workflow for better code quality assurance.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gofrp/tiny-frpc?shareId=1c43927c-38f0-486f-823d-0d4f716aac88).