### PR TITLE
Update Go version to 1.22

### DIFF
--- a/.github/workflows/go-code-check.yml
+++ b/.github/workflows/go-code-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Build
         run: make

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
       - name: Make All
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofrp/tiny-frpc
 
-go 1.21
+go 1.22
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.2


### PR DESCRIPTION
Related to #23

Updates the Go version to 1.22 in the `go.mod` file and GitHub Actions workflows.

- Updates the Go version specification in `go.mod` from 1.21 to 1.22.
- Modifies `.github/workflows/goreleaser.yml` and `.github/workflows/go-code-check.yml` to use Go 1.22 for setup-go action.
