### PR TITLE
Add file size check for tiny-frpc 2 binary files

### DIFF
--- a/.github/workflows/go-code-check.yml
+++ b/.github/workflows/go-code-check.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Test
         run: make test
+
+      - name: Check File Size
+        run: make check-size

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export PATH := $(GOPATH)/bin:$(PATH)
 LDFLAGS := -s -w
 
-all: fmt build
+all: fmt build check-size
 
 build: gssh nssh
 
@@ -22,6 +22,17 @@ gssh:
 
 nssh:
 	env CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -tags nssh -o bin/tiny-frpc-ssh ./cmd/frpc
+
+check-size:
+	@echo "Checking file sizes..."
+	@FRPC_SIZE=$$(stat -c%s "./bin/tiny-frpc"); \
+	FRPC_SSH_SIZE=$$(stat -c%s "./bin/tiny-frpc-ssh"); \
+	if [ $$FRPC_SSH_SIZE -gt $$FRPC_SIZE ]; then \
+		echo "Error: tiny-frpc-ssh ($$FRPC_SSH_SIZE bytes) is larger than tiny-frpc ($$FRPC_SIZE bytes)"; \
+		exit 1; \
+	else \
+		echo "File size check passed: tiny-frpc-ssh ($$FRPC_SSH_SIZE bytes) is not larger than tiny-frpc ($$FRPC_SIZE bytes)"; \
+	fi
 
 test: gotest
 


### PR DESCRIPTION
Related to #26

Adds a new CI check and a Makefile target to ensure `tiny-frpc-ssh` file size does not exceed `tiny-frpc`.

- **Makefile Changes:**
  - Introduces a new target `check-size` that compares the file sizes of `tiny-frpc` and `tiny-frpc-ssh`. If `tiny-frpc-ssh` is larger, it prints an error message and exits with a non-zero status.
  - Adds `check-size` as a dependency to the `all` target, ensuring the file size check is performed during the build process.

- **CI Workflow Changes:**
  - Adds a new step named "Check File Size" in the `.github/workflows/go-code-check.yml` workflow, which runs after the test step. This step executes the `check-size` target from the Makefile to enforce the file size restriction in the CI environment.
